### PR TITLE
fix: overwrite

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,6 @@ pub struct Args {
     pub nb_properties: u8,
 
     /// Overwrite existing files
-    #[arg(short, long, action = clap::ArgAction::SetFalse)]
+    #[arg(short, long, default_value_t = false)]
     pub overwrite: bool,
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -79,10 +79,24 @@ fn generate_parents(
 
 /// Move the content of a temp folder to the fuzz test folder
 fn move_temp_contents(temp_dir: &TempDir, overwrite: bool) -> Result<()> {
+    let path = Path::new("./test/invariants/fuzz");
+    if path.exists() {
+        if !overwrite {
+            return Err(anyhow::anyhow!(
+                "Fuzz test folder already exists, did you mean --overwrite ?"
+            ));
+        }
+    } else {
+        DirBuilder::new()
+            .recursive(true)
+            .create(path)
+            .context("Failed to create fuzz test folder")?;
+    }
+
     let options = CopyOptions {
         overwrite,
-        skip_exist: false,
-        copy_inside: true,
+        skip_exist: !overwrite,
+        content_only: true,
         ..Default::default()
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,12 +113,12 @@ impl ContractType {
 
     pub fn import(&self) -> &'static str {
         match self {
-            ContractType::Handler => "import {Setup} from '../Setup.t.sol';",
+            ContractType::Handler => "import {Setup} from '../Setup.t.sol';\n",
             ContractType::Property => {
-                "import {HandlersParent} from '../handlers/HandlersParent.t.sol';"
+                "import {HandlersParent} from '../handlers/HandlersParent.t.sol';\n"
             }
             ContractType::EntryPoint => {
-                "import {PropertiesParent} from './properties/PropertiesParent.t.sol';"
+                "import {PropertiesParent} from './properties/PropertiesParent.t.sol';\n"
             }
             ContractType::Setup => "",
         }


### PR DESCRIPTION
Fix the `--overwrite` flag so it's:
- default to false
- does not copy the temp dir if false (was creating a new subdir with the temp dir name, `.lksju32` eg)
- create the correct dir if needed
- overwrite if needed